### PR TITLE
maintaining the data in a JSON

### DIFF
--- a/.doxie.render.js
+++ b/.doxie.render.js
@@ -1,0 +1,18 @@
+var render = function(data) {
+  var data = data.data;
+
+  return [
+    '## ' + data.title,
+    '',
+    data.description,
+    '',
+    '```js',
+    '"scripts": {',
+    '  "' + data.key + ': "' + data.script + '"',
+    '}',
+    '```',
+    '\n'
+  ].join('\n');
+};
+
+module.exports = render;

--- a/README.md
+++ b/README.md
@@ -1,21 +1,45 @@
 # Collection of useful npm-scripts!
 
-## Release 
+<!-- @doxie.inject start -->
+<!-- Don’t remove or change the comment above – that can break automatic updates. -->
+## minor-release
+
+Publish a minor release of a package
 
 ```js
 "scripts": {
-  "minor-release": "npm version patch && npm publish && git push --follow-tags",
-  "patch-release": "npm version patch && npm publish && git push --follow-tags",
-  "major-release": "npm version major && npm publish && git push --follow-tags"
+  "minor-release: "npm version patch && npm publish && git push --follow-tags"
 }
 ```
 
-## Bower install before npm 
+## patch-release
+
+Publish a patch release of a package
 
 ```js
 "scripts": {
-    "postinstall": "bower install"
-  }
+  "patch-release: "npm version patch && npm publish && git push --follow-tags"
+}
+```
+
+## major-release
+
+Publish a major release of a package
+
+```js
+"scripts": {
+  "major-release: "npm version major && npm publish && git push --follow-tags"
+}
+```
+
+## Bower postinstall
+
+Bower install before npm
+
+```js
+"scripts": {
+  "postinstall: "bower install"
+}
 ```
 
 ## gh-pages
@@ -24,6 +48,9 @@ Pushs a folder (f.e. `docs`) to the `gh-pages` branch.
 
 ```js
 "scripts": {
-  "update-gh-pages": "git push origin `git subtree split --prefix docs master`:gh-pages --force"
+  "update-gh-pages: "git push origin `git subtree split --prefix docs master`:gh-pages --force"
 }
 ```
+
+<!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->
+<!-- @doxie.inject end -->

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "npm",
     "scripts"
   ],
-  "author": "schtoeffel",
+  "contributors": [
+    "hemanth",
+    "schtoeffel"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/npm-scripts/scripts/issues"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "scripts",
+  "version": "1.0.0",
+  "description": "collection of npm scripts",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm-scripts/scripts.git"
+  },
+  "keywords": [
+    "npm",
+    "scripts"
+  ],
+  "author": "schtoeffel",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/npm-scripts/scripts/issues"
+  },
+  "homepage": "https://github.com/npm-scripts/scripts#readme",
+  "devDependencies": {
+    "doxie": "^0.2.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "collection of npm scripts",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "create-readme": "doxie --render --output < ./scripts.json --inject into README.md"
   },
   "repository": {
     "type": "git",
@@ -24,6 +25,9 @@
   },
   "homepage": "https://github.com/npm-scripts/scripts#readme",
   "devDependencies": {
-    "doxie": "^0.2.2"
+    "doxie": "^0.2.2",
+    "doxie.inject": "^0.1.1",
+    "doxie.output": "^0.3.0",
+    "doxie.render": "^0.3.0"
   }
 }

--- a/scripts.json
+++ b/scripts.json
@@ -1,0 +1,55 @@
+[
+  {
+    "title": "minor-release",
+    "description": "Publish a minor release of a package",
+    "key": "minor-release",
+    "script": "npm version patch && npm publish && git push --follow-tags",
+    "keywords": [
+      "npm",
+      "release",
+      "push",
+      "publish"
+    ]
+  }, {
+    "title": "patch-release",
+    "description": "Publish a patch release of a package",
+    "key": "patch-release",
+    "script": "npm version patch && npm publish && git push --follow-tags",
+    "keywords": [
+      "npm",
+      "release",
+      "push",
+      "publish"
+    ]
+  }, {
+    "title": "major-release",
+    "description": "Publish a major release of a package",
+    "key": "major-release",
+    "script": "npm version major && npm publish && git push --follow-tags",
+    "keywords": [
+      "npm",
+      "release",
+      "push",
+      "publish"
+    ]
+  }, {
+    "title": "Bower postinstall",
+    "description": "Bower install before npm",
+    "key": "postinstall",
+    "script": "bower install",
+    "keywords": [
+      "npm",
+      "bower",
+      "postinstall"
+    ]
+  }, {
+    "title": "gh-pages",
+    "description": "Pushs a folder (f.e. `docs`) to the `gh-pages` branch.",
+    "key": "update-gh-pages",
+    "script": "git push origin `git subtree split --prefix docs master`:gh-pages --force",
+    "keywords": [
+      "npm",
+      "gh-pages"
+    ]
+  }
+]


### PR DESCRIPTION
This is an initial PR to move the data to a JSON file and creating the README by running
`npm run create-readme` (it uses [doxie](https://github.com/studio-b12/doxie) for that).
This will allow us later to use the data in f.e. a CLI-tool.

Maybe we can even group the data. @tomekwi is this possible?

How do you like this @hemanth?

refs https://github.com/npm-scripts/meta/issues/2
